### PR TITLE
Numpy random choice instead of torch.multinomial

### DIFF
--- a/models/AttModel.py
+++ b/models/AttModel.py
@@ -139,7 +139,7 @@ class AttModel(CaptionModel):
                     #it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1))
                     # prob_prev = torch.exp(outputs[-1].data) # fetch prev distribution: shape Nx(M+1)
                     prob_prev = torch.exp(outputs[:, i-1].detach()) # fetch prev distribution: shape Nx(M+1)
-                    it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
+                    it.index_copy_(0, sample_ind, utils.np_multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
             else:
                 it = seq[:, i].clone()          
             # break if all the sequences end

--- a/models/FCModel.py
+++ b/models/FCModel.py
@@ -96,7 +96,7 @@ class FCModel(CaptionModel):
                         #prob_prev = torch.exp(outputs[-1].data.index_select(0, sample_ind)) # fetch prev distribution: shape Nx(M+1)
                         #it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1))
                         prob_prev = torch.exp(outputs[-1].data) # fetch prev distribution: shape Nx(M+1)
-                        it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
+                        it.index_copy_(0, sample_ind, utils.np_multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
                 else:
                     it = seq[:, i-1].clone()
                 # break if all the sequences end
@@ -181,7 +181,7 @@ class FCModel(CaptionModel):
                 else:
                     # scale logprobs by temperature
                     prob_prev = torch.exp(torch.div(logprobs.data, temperature)).cpu()
-                it = torch.multinomial(prob_prev, 1).cuda()
+                it = utils.np_multinomial(prob_prev, 1).cuda()
                 sampleLogprobs = logprobs.gather(1, it) # gather the logprobs at sampled positions
                 it = it.view(-1).long() # and flatten indices for downstream processing
 

--- a/models/OldModel.py
+++ b/models/OldModel.py
@@ -70,7 +70,7 @@ class OldModel(CaptionModel):
                     #prob_prev = torch.exp(outputs[-1].data.index_select(0, sample_ind)) # fetch prev distribution: shape Nx(M+1)
                     #it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1))
                     prob_prev = torch.exp(outputs[-1].data) # fetch prev distribution: shape Nx(M+1)
-                    it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
+                    it.index_copy_(0, sample_ind, utils.np_multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
             else:
                 it = seq[:, i].clone()          
             # break if all the sequences end
@@ -152,7 +152,7 @@ class OldModel(CaptionModel):
                 else:
                     # scale logprobs by temperature
                     prob_prev = torch.exp(torch.div(logprobs.data, temperature)).cpu()
-                it = torch.multinomial(prob_prev, 1).cuda()
+                it = utils.np_multinomial(prob_prev, 1).cuda()
                 sampleLogprobs = logprobs.gather(1, it) # gather the logprobs at sampled positions
                 it = it.view(-1).long() # and flatten indices for downstream processing
 

--- a/models/ShowTellModel.py
+++ b/models/ShowTellModel.py
@@ -66,7 +66,7 @@ class ShowTellModel(CaptionModel):
                         #prob_prev = torch.exp(outputs[-1].data.index_select(0, sample_ind)) # fetch prev distribution: shape Nx(M+1)
                         #it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1))
                         prob_prev = torch.exp(outputs[-1].data) # fetch prev distribution: shape Nx(M+1)
-                        it.index_copy_(0, sample_ind, torch.multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
+                        it.index_copy_(0, sample_ind, utils.np_multinomial(prob_prev, 1).view(-1).index_select(0, sample_ind))
                 else:
                     it = seq[:, i-1].clone()                
                 # break if all the sequences end
@@ -151,7 +151,7 @@ class ShowTellModel(CaptionModel):
                 else:
                     # scale logprobs by temperature
                     prob_prev = torch.exp(torch.div(logprobs.data, temperature)).cpu()
-                it = torch.multinomial(prob_prev, 1).cuda()
+                it = utils.np_multinomial(prob_prev, 1).cuda()
                 sampleLogprobs = logprobs.gather(1, it) # gather the logprobs at sampled positions
                 it = it.view(-1).long() # and flatten indices for downstream processing
 


### PR DESCRIPTION
See pytorch issues https://github.com/pytorch/pytorch/issues/13018 and https://github.com/pytorch/pytorch/issues/11931. Basically, for relatively small batch sizes and large number of categories `torch.multinomial` (even on GPU) is much slower than `numpy.random.choice` (on CPU). When training with self-critical RL, every model at every timestep samples from its multinomial output distribution to generate sentences, so this affects performance. From a `cProfile` run with batch_size 32 on a single GPU:
```
         37175656 function calls (37122158 primitive calls) in 203.291 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
     1700  101.842    0.060  101.842    0.060 {built-in method multinomial}
   192150   34.415    0.000   44.556    0.000 cider/pyciderevalcap/ciderD/ciderD_scorer.py:128(counts2vec)
   160150   13.956    0.000   17.723    0.000 cider/pyciderevalcap/ciderD/ciderD_scorer.py:154(sim)
   192150    8.991    0.000    9.246    0.000 cider/pyciderevalcap/ciderD/ciderD_scorer.py:17(precook)
        1    5.165    5.165    5.165    5.165 {built-in method _pickle.load}
  7623303    4.280    0.000    4.280    0.000 {built-in method builtins.pow}
  7465105    2.906    0.000    2.906    0.000 {built-in method builtins.min}
  7623749    2.610    0.000    2.610    0.000 {built-in method builtins.max}
     2127    2.496    0.001    2.512    0.001 {method 'cuda' of 'torch._C._TensorBase' objects}
      100    2.389    0.024   66.255    0.663 cider/pyciderevalcap/ciderD/ciderD_scorer.py:127(compute_cider)
```
And output from the training script (not the same run, sorry):
```
iter 50 (epoch 0), avg_reward = 0.000, time/batch = 1.157
iter 100 (epoch 0), avg_reward = 0.001, time/batch = 1.167
iter 150 (epoch 0), avg_reward = 0.000, time/batch = 1.163
iter 200 (epoch 0), avg_reward = -0.001, time/batch = 1.161
iter 250 (epoch 0), avg_reward = -0.001, time/batch = 1.152
iter 300 (epoch 0), avg_reward = -0.003, time/batch = 1.166
iter 350 (epoch 0), avg_reward = -0.001, time/batch = 1.368
iter 400 (epoch 0), avg_reward = 0.000, time/batch = 1.155
iter 450 (epoch 0), avg_reward = -0.001, time/batch = 1.191
iter 500 (epoch 0), avg_reward = 0.001, time/batch = 1.165
total time: 627.1329505443573
```

As you can see `torch.multinomial` takes by far most of the time. So I added a method in `utils.py` that casts the `torch.multinomial` API into the `numpy.random.choice` API and changed the calls in `models`. This is the output from a `cProfile` run with the exact same options and number of iterations:
```
         44585803 function calls (44532304 primitive calls) in 170.036 seconds

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
   272000   48.225    0.000   55.919    0.000 {method 'choice' of 'numpy.random.mtrand.RandomState' objects}
   192150   33.483    0.000   43.641    0.000 cider/pyciderevalcap/ciderD/ciderD_scorer.py:128(counts2vec)
   160150   13.217    0.000   16.636    0.000 cider/pyciderevalcap/ciderD/ciderD_scorer.py:154(sim)
   192150    9.130    0.000    9.386    0.000 cider/pyciderevalcap/ciderD/ciderD_scorer.py:17(precook)
   592303    5.838    0.000    5.838    0.000 {method 'reduce' of 'numpy.ufunc' objects}
        1    5.238    5.238    5.238    5.238 {built-in method _pickle.load}
     1700    4.794    0.003   70.158    0.041 /export/home1/NoCsBack/hci/rubenc/selfcritical/misc/utils.py:282(np_multinomial)
   272000    4.730    0.000    8.446    0.000 /export/home1/NoCsBack/hci/rubenc/miniconda3/envs/transfenv/lib/python3.7/site-packages/numpy/linalg/linalg.py:2325(norm)
  7528939    4.246    0.000    4.246    0.000 {built-in method builtins.pow}
  7529385    2.672    0.000    2.672    0.000 {built-in method builtins.max}
```
And
```
iter 50 (epoch 0), avg_reward = 0.000, time/batch = 0.952
iter 100 (epoch 0), avg_reward = 0.001, time/batch = 0.960
iter 150 (epoch 0), avg_reward = 0.001, time/batch = 0.956
iter 200 (epoch 0), avg_reward = 0.002, time/batch = 0.963
iter 250 (epoch 0), avg_reward = -0.000, time/batch = 1.136
iter 300 (epoch 0), avg_reward = 0.000, time/batch = 0.954
iter 350 (epoch 0), avg_reward = 0.001, time/batch = 1.115
iter 400 (epoch 0), avg_reward = 0.001, time/batch = 0.958
iter 450 (epoch 0), avg_reward = 0.001, time/batch = 0.938
iter 500 (epoch 0), avg_reward = 0.001, time/batch = 0.940
total time: 523.3232505321503
```

Clearly this gives a substantial speedup.

And a comparison in `ipython` (both torch and numpy on CPU though):
```python
In [108]: weights = torch.randn((32, 20000), dtype=torch.float32).clamp(0.01, 1)

In [106]: avg_timeit(lambda: np_multinomial(weights, 1), 100)
Out[106]: 0.011828489303588867

In [107]: avg_timeit(lambda: torch.multinomial(weights, 1), 100)
Out[107]: 0.044491004943847653
```
Shows a +/- 4x speedup 🙂.